### PR TITLE
Fix after MATSim1330; Use carrierScenarioElement from MATSim-freight instead of defining a new one internally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 <!--		<matsim.version>13.0-SNAPSHOT</matsim.version>-->
-		<matsim.version>13.0-2021w01-SNAPSHOT</matsim.version>
+		<matsim.version>13.0-2021w02-SNAPSHOT</matsim.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/receiver/ReceiverControlerListener.java
+++ b/src/main/java/receiver/ReceiverControlerListener.java
@@ -27,6 +27,7 @@ import org.matsim.api.core.v01.population.HasPlansAndId;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.carrier.Tour;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.events.BeforeMobsimEvent;
@@ -43,7 +44,6 @@ import org.matsim.core.utils.misc.Time;
 import receiver.replanning.ReceiverOrderStrategyManagerFactory;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -187,7 +187,7 @@ class ReceiverControlerListener implements ScoringListener,
             bw.write("receiverId,twStart,twEnd,twDuration,positionInTour,product,deliveryStart,deliveryEnd");
             bw.newLine();
 
-            for (Carrier carrier : ReceiverUtils.getCarriers(this.sc).getCarriers().values()) {
+			for (Carrier carrier : FreightUtils.getCarriers(this.sc).getCarriers().values()) {
                 Collection<ScheduledTour> scheduledTours = carrier.getSelectedPlan().getScheduledTours();
                 for (ScheduledTour tour : scheduledTours) {
                     for (int i = 0; i < tour.getTour().getTourElements().size(); i++) {

--- a/src/main/java/receiver/ReceiverScoreStats.java
+++ b/src/main/java/receiver/ReceiverScoreStats.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.carrier.CarrierPlanXmlWriterV2;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.events.ShutdownEvent;
@@ -94,7 +95,7 @@ final class ReceiverScoreStats implements StartupListener, IterationEndsListener
         /* Write the carrier and receiver plans at specific iterations */
         if((event.getIteration() + 1) % (ConfigUtils.addOrGetModule(sc.getConfig(), ReceiverConfigGroup.class).getReceiverReplanningInterval()) != 0) return;
         String dir = event.getServices().getControlerIO().getIterationPath(event.getIteration());
-        new CarrierPlanXmlWriterV2( ReceiverUtils.getCarriers( sc ) ).write(dir + "/" + event.getIteration() + CARRIER_PLANS_XML);
+		new CarrierPlanXmlWriterV2(FreightUtils.getCarriers(sc)).write(dir + "/" + event.getIteration() + CARRIER_PLANS_XML);
         new ReceiversWriter( ReceiverUtils.getReceivers( sc ) ).write(dir + "/" + event.getIteration() + RECEIVER_PLANS_XML);
     }
 

--- a/src/main/java/receiver/ReceiverUtils.java
+++ b/src/main/java/receiver/ReceiverUtils.java
@@ -20,7 +20,7 @@ public class ReceiverUtils {
 	public static final String ATTR_RECEIVER_SCORE = "score" ;
 	public static final String ATTR_RECEIVER_TW_COST = "twCost" ;
 
-	private static final String CARRIERS_SCENARIO_ELEMENT = "Carriers";
+	private static final String CARRIERS_SCENARIO_ELEMENT = "carriers";
 	private static final String RECEIVERS_SCENARIO_ELEMENT = "Receivers" ;
 	private static final String COALITION_SCENARIO_ELEMENT = "Coalition" ;
 

--- a/src/main/java/receiver/ReceiverUtils.java
+++ b/src/main/java/receiver/ReceiverUtils.java
@@ -4,6 +4,7 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.carrier.Carriers;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.scenario.MutableScenario;
@@ -20,7 +21,10 @@ public class ReceiverUtils {
 	public static final String ATTR_RECEIVER_SCORE = "score" ;
 	public static final String ATTR_RECEIVER_TW_COST = "twCost" ;
 
-	private static final String CARRIERS_SCENARIO_ELEMENT = "carriers";
+	//Now using the MATSim-infrastructure to avoid problems if this element is named differently beetween (MATSim) FreightUtils and here.
+	// I also replaced the usage here by the current MATSim syntax KMT'jan21
+//	private static final String CARRIERS_SCENARIO_ELEMENT = "carriers";
+
 	private static final String RECEIVERS_SCENARIO_ELEMENT = "Receivers" ;
 	private static final String COALITION_SCENARIO_ELEMENT = "Coalition" ;
 
@@ -36,14 +40,14 @@ public class ReceiverUtils {
 		return new ReceiverImpl(id);
 	}
 
-	/**
-	 * This can now be replaced with {@link org.matsim.contrib.freight.utils.FreightUtils#getCarriers(Scenario)}
-	 */
-	@Deprecated
-	public static Carriers getCarriers( final Scenario sc ) {
-		return (Carriers) sc.getScenarioElement( CARRIERS_SCENARIO_ELEMENT );
-	}
-	
+//	/**
+//	 * This can now be replaced with {@link org.matsim.contrib.freight.utils.FreightUtils#getCarriers(Scenario)}
+//	 */
+//	@Deprecated
+//	public static Carriers getCarriers( final Scenario sc ) {
+//		return (Carriers) sc.getScenarioElement( CARRIERS_SCENARIO_ELEMENT );
+//	}
+
 	public static void setReceivers( final Receivers receivers, final Scenario sc ) {
 		sc.addScenarioElement( RECEIVERS_SCENARIO_ELEMENT, receivers );
 	}
@@ -63,10 +67,14 @@ public class ReceiverUtils {
 		}
 		return receivers;
 	}
-	
-	public static void setCarriers( final Carriers carriers, final Scenario sc ) {
-		sc.addScenarioElement( CARRIERS_SCENARIO_ELEMENT, carriers );
-	}
+
+	//Can be replaced by:
+	// 	Carriers carriers = FreightUtils.getOrCreateCarriers(sc);
+	//	carriers.addCarrier(carrier);
+	// KMT, Jan'21
+//	public static void setCarriers( final Carriers carriers, final Scenario sc ) {
+//		sc.addScenarioElement( CARRIERS_SCENARIO_ELEMENT, carriers );
+//	}
 	
 	public static void setCoalition( final Coalition coalition, final Scenario sc ) {
 		sc.addScenarioElement( COALITION_SCENARIO_ELEMENT, coalition );

--- a/src/main/java/receiver/collaboration/CollaborationUtils.java
+++ b/src/main/java/receiver/collaboration/CollaborationUtils.java
@@ -2,6 +2,7 @@ package receiver.collaboration;
 
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.carrier.Carrier;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import receiver.Receiver;
 import receiver.ReceiverUtils;
 
@@ -32,7 +33,7 @@ public class CollaborationUtils{
 		/* Add carrier and receivers to coalition */
 		Coalition coalition = CollaborationUtils.createCoalition();
 
-		for (Carrier carrier : ReceiverUtils.getCarriers( sc ).getCarriers().values()){
+		for (Carrier carrier : FreightUtils.getCarriers(sc).getCarriers().values()){
 			if (!coalition.getCarrierCoalitionMembers().contains(carrier)){
 				coalition.addCarrierCoalitionMember(carrier);
 			}

--- a/src/main/java/receiver/collaboration/MarginalCostSharing.java
+++ b/src/main/java/receiver/collaboration/MarginalCostSharing.java
@@ -13,6 +13,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.TimeWindow;
 
+import org.matsim.contrib.freight.utils.FreightUtils;
 import receiver.Receiver;
 import receiver.ReceiverPlan;
 import receiver.ReceiverUtils;
@@ -81,7 +82,7 @@ public final class MarginalCostSharing implements ReceiverCarrierCostAllocation 
 		while (iterator.hasNext()){
 
 			Id<Carrier> carrierId = iterator.next();
-			Carrier carrier = ReceiverUtils.getCarriers( sc ).getCarriers().get(carrierId);
+			Carrier carrier = FreightUtils.getCarriers(sc).getCarriers().get(carrierId);
 //			double fixedFeeVolume = 0.0;
 //			
 //			/* Determine the total volume of non-coalition members. */

--- a/src/main/java/receiver/collaboration/ProportionalCostSharing.java
+++ b/src/main/java/receiver/collaboration/ProportionalCostSharing.java
@@ -29,6 +29,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.TimeWindow;
 
+import org.matsim.contrib.freight.utils.FreightUtils;
 import receiver.Receiver;
 import receiver.ReceiverPlan;
 import receiver.ReceiverUtils;
@@ -96,7 +97,7 @@ public final class ProportionalCostSharing implements ReceiverCarrierCostAllocat
 			// (go through the carriers one by one)
 
 			Id<Carrier> carrierId = entry.getKey() ;
-			Carrier carrier = ReceiverUtils.getCarriers( sc ).getCarriers().get(carrierId);
+			Carrier carrier = FreightUtils.getCarriers(sc).getCarriers().get(carrierId);
 			final List<Receiver> receiverList = entry.getValue();
 
 			double fixedFeeVolume = 0.0;

--- a/src/main/java/receiver/replanning/ReceiverResponseCarrierReplanning.java
+++ b/src/main/java/receiver/replanning/ReceiverResponseCarrierReplanning.java
@@ -24,13 +24,11 @@ import com.graphhopper.jsprit.core.util.Solutions;
 import com.graphhopper.jsprit.io.algorithm.VehicleRoutingAlgorithms;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.contrib.freight.carrier.Carrier;
-import org.matsim.contrib.freight.carrier.CarrierPlan;
-import org.matsim.contrib.freight.carrier.CarrierPlanXmlWriterV2;
-import org.matsim.contrib.freight.carrier.CarrierShipment;
+import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.jsprit.MatsimJspritFactory;
 import org.matsim.contrib.freight.jsprit.NetworkBasedTransportCosts;
 import org.matsim.contrib.freight.jsprit.NetworkRouter;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.events.IterationStartsEvent;
 import org.matsim.core.controler.listener.IterationStartsListener;
@@ -62,7 +60,7 @@ public class ReceiverResponseCarrierReplanning implements IterationStartsListene
         CollaborationUtils.setCoalitionFromReceiverAttributes( sc );
 
         // clean out plans, services, shipments from carriers:
-        Map<Id<Carrier>, Carrier> carriers = ReceiverUtils.getCarriers( sc ).getCarriers();
+		Map<Id<Carrier>, Carrier> carriers = FreightUtils.getCarriers(sc).getCarriers();
         for( Carrier carrier : carriers.values() ){
             carrier.clearPlans();
             carrier.getShipments().clear();
@@ -121,7 +119,7 @@ public class ReceiverResponseCarrierReplanning implements IterationStartsListene
 
         }
 
-        new CarrierPlanXmlWriterV2( ReceiverUtils.getCarriers( sc ) ).write(sc.getConfig().controler().getOutputDirectory() + "carriers.xml");
+		new CarrierPlanXmlWriterV2(FreightUtils.getCarriers(sc)).write(sc.getConfig().controler().getOutputDirectory() + "carriers.xml");
         new ReceiversWriter( ReceiverUtils.getReceivers( sc ) ).write(sc.getConfig().controler().getOutputDirectory() + "receivers.xml");
 
     }

--- a/src/main/java/receiver/usecases/capetown/CapeTownReceiverUtils.java
+++ b/src/main/java/receiver/usecases/capetown/CapeTownReceiverUtils.java
@@ -22,15 +22,13 @@
 package receiver.usecases.capetown;
 
 import org.apache.log4j.Logger;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.controler.Controler;
 import receiver.ReceiverModule;
-import receiver.ReceiverScoringFunctionFactory;
 import receiver.ReceiverUtils;
 import receiver.Receivers;
 import receiver.collaboration.Coalition;
-import receiver.replanning.ReceiverOrderStrategyManagerFactory;
 import receiver.replanning.ReceiverReplanningType;
-import receiver.usecases.UsecasesReceiverScoringFunctionFactory;
 
 /**
  *
@@ -45,7 +43,7 @@ public class CapeTownReceiverUtils {
 
 		Receivers finalReceivers = ReceiverUtils.getReceivers( controler.getScenario() );
 
-		finalReceivers.linkReceiverOrdersToCarriers( ReceiverUtils.getCarriers( controler.getScenario() ) );
+		finalReceivers.linkReceiverOrdersToCarriers(FreightUtils.getCarriers(controler.getScenario()));
 		// (presumably done twice, just to be sure)
 
 		Coalition coalition = ReceiverUtils.getCoalition( controler.getScenario() );

--- a/src/main/java/receiver/usecases/capetown/CapeTownScenarioBuilder.java
+++ b/src/main/java/receiver/usecases/capetown/CapeTownScenarioBuilder.java
@@ -38,6 +38,7 @@ import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
 import org.matsim.contrib.freight.jsprit.MatsimJspritFactory;
 import org.matsim.contrib.freight.jsprit.NetworkBasedTransportCosts;
 import org.matsim.contrib.freight.jsprit.NetworkRouter;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.ConfigWriter;
@@ -117,7 +118,7 @@ public class CapeTownScenarioBuilder {
 		}
 
 		/* Link the carriers to the receivers. */
-		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers( ReceiverUtils.getCarriers( sc ) );
+		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers(FreightUtils.getCarriers(sc));
 		CollaborationUtils.createCoalitionWithCarriersAndAddCollaboratingReceivers(sc);
 		return sc;
 	}
@@ -161,7 +162,7 @@ public class CapeTownScenarioBuilder {
 		}
 
 		/* Link the carriers to the receivers. */
-		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers( ReceiverUtils.getCarriers( sc ) );
+		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers(FreightUtils.getCarriers(sc));
 
 		/* Set coalition settings */
 		CollaborationUtils.createCoalitionWithCarriersAndAddCollaboratingReceivers( sc );
@@ -259,13 +260,13 @@ public class CapeTownScenarioBuilder {
 		new File(outputFolder).mkdirs();
 
 		new ConfigWriter(sc.getConfig()).write(outputFolder + "config.xml");
-		new CarrierPlanXmlWriterV2( ReceiverUtils.getCarriers( sc ) ).write(outputFolder + "carriers.xml");
+		new CarrierPlanXmlWriterV2(FreightUtils.getCarriers(sc)).write(outputFolder + "carriers.xml");
 		new ReceiversWriter( ReceiverUtils.getReceivers( sc ) ).write(outputFolder + "receivers.xml");
 
 		/* Write the vehicle types. FIXME This will have to change so that vehicle
 		 * types lie at the Carriers level, and not per Carrier. In this scenario 
 		 * there luckily is only a single Carrier. */
-		new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes( ReceiverUtils.getCarriers( sc ) )).write(outputFolder + "carrierVehicleTypes.xml");
+		new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes(FreightUtils.getCarriers(sc))).write(outputFolder + "carrierVehicleTypes.xml");
 	}
 
 	/**
@@ -274,7 +275,7 @@ public class CapeTownScenarioBuilder {
 	 * @param sc
 	 */
 	public static void generateCarrierPlan(Scenario sc ) {
-		Carrier carrier = ReceiverUtils.getCarriers(sc).getCarriers().get(Id.create("Carrier1", Carrier.class)); 
+		Carrier carrier = FreightUtils.getCarriers(sc).getCarriers().get(Id.create("Carrier1", Carrier.class));
 
 		VehicleRoutingProblem.Builder vrpBuilder = MatsimJspritFactory.createRoutingProblemBuilder(carrier, sc.getNetwork());
 
@@ -314,7 +315,7 @@ public class CapeTownScenarioBuilder {
 	 * @param sc
 	 */
 	public static void createReceiverOrders( Scenario sc ) {
-		Carriers carriers = ReceiverUtils.getCarriers( sc );
+		Carriers carriers = FreightUtils.getCarriers(sc);
 		Receivers receivers = ReceiverUtils.getReceivers( sc );
 		Carrier carrierOne = carriers.getCarriers().get(Id.create("Carrier1", Carrier.class));
 		/* This we added to facilitate the shipments */
@@ -545,9 +546,8 @@ public class CapeTownScenarioBuilder {
 		types.getVehicleTypes().put(typeMedium.getId(), typeMedium);
 		types.getVehicleTypes().put(typeHeavy.getId(), typeHeavy);
 
-		Carriers carriers = new Carriers();
+		Carriers carriers = FreightUtils.getOrCreateCarriers(sc);
 		carriers.addCarrier(carrier);
-		ReceiverUtils.setCarriers(carriers, sc);
 	}
 
 

--- a/src/main/java/receiver/usecases/capetown/RunCapeTownReceiver.java
+++ b/src/main/java/receiver/usecases/capetown/RunCapeTownReceiver.java
@@ -28,14 +28,12 @@ import java.io.File;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.usecases.analysis.CarrierScoreStats;
-import org.matsim.core.config.ConfigUtils;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 
 import org.matsim.core.utils.io.IOUtils;
-import receiver.ReceiverConfigGroup;
-import receiver.ReceiverUtils;
 import receiver.usecases.chessboard.ReceiverChessboardUtils;
 
 /**
@@ -161,7 +159,7 @@ public class RunCapeTownReceiver {
 
 	static void prepareFreightOutputDataAndStats( MatsimServices controler, int run ) {
 
-		CarrierScoreStats scoreStats = new CarrierScoreStats( ReceiverUtils.getCarriers( controler.getScenario() ), controler.getScenario().getConfig().controler().getOutputDirectory() + "/carrier_scores", true);
+		CarrierScoreStats scoreStats = new CarrierScoreStats(FreightUtils.getCarriers(controler.getScenario()), controler.getScenario().getConfig().controler().getOutputDirectory() + "/carrier_scores", true);
 
 		controler.addControlerListener(scoreStats);
 		controler.addControlerListener(new VehicleTypeListener(controler.getScenario(), run));

--- a/src/main/java/receiver/usecases/capetown/VehicleTypeListener.java
+++ b/src/main/java/receiver/usecases/capetown/VehicleTypeListener.java
@@ -18,6 +18,7 @@ import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.CarrierPlan;
 import org.matsim.contrib.freight.carrier.Carriers;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.events.StartupEvent;
 import org.matsim.core.controler.listener.IterationEndsListener;
@@ -25,8 +26,6 @@ import org.matsim.core.controler.listener.StartupListener;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
-
-import receiver.ReceiverUtils;
 
 
 /**
@@ -46,7 +45,7 @@ public class VehicleTypeListener implements StartupListener, IterationEndsListen
 
 	
 	public VehicleTypeListener(Scenario sc, int run) {
-		this.carriers = ReceiverUtils.getCarriers(sc);
+		this.carriers = FreightUtils.getCarriers(sc);
 		this.run = run;
 //		this.tw = tw;
 //		this.delFreq = delFreq;

--- a/src/main/java/receiver/usecases/chessboard/BaseReceiverChessboardScenario.java
+++ b/src/main/java/receiver/usecases/chessboard/BaseReceiverChessboardScenario.java
@@ -31,6 +31,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.NetworkWriter;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.ConfigWriter;
@@ -91,7 +92,7 @@ public class BaseReceiverChessboardScenario{
 		}
 
 		/* Link the carriers to the receivers. */
-		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers( ReceiverUtils.getCarriers( sc ) );
+		 ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers(FreightUtils.getCarriers(sc));
 		CollaborationUtils.createCoalitionWithCarriersAndAddCollaboratingReceivers( sc );
 		return sc;
 	}
@@ -125,14 +126,14 @@ public class BaseReceiverChessboardScenario{
 
 		new NetworkWriter(sc.getNetwork()).write(outputFolder + "network.xml");
 		new ConfigWriter(sc.getConfig()).write(outputFolder + "config.xml");
-		new CarrierPlanXmlWriterV2( ReceiverUtils.getCarriers( sc ) ).write(outputFolder + "carriers.xml");
+		new CarrierPlanXmlWriterV2(FreightUtils.getCarriers(sc)).write(outputFolder + "carriers.xml");
 //		new CarrierPlanWriter(ReceiverUtils.getCarriers( sc ).getCarriers().values()).write(outputFolder + "carriers.xml");
 		new ReceiversWriter( ReceiverUtils.getReceivers( sc ) ).write(outputFolder + "receivers.xml");
 
 		/* Write the vehicle types. FIXME This will have to change so that vehicle
 		 * types lie at the Carriers level, and not per Carrier. In this scenario
 		 * there luckily is only a single Carrier. */
-		new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes( ReceiverUtils.getCarriers( sc ) )).write(outputFolder + "carrierVehicleTypes.xml");
+		new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes(FreightUtils.getCarriers(sc))).write(outputFolder + "carrierVehicleTypes.xml");
 	}
 
 
@@ -141,7 +142,7 @@ public class BaseReceiverChessboardScenario{
 	 * for experiments, but this must be adapted in the future to accept other parameters as inputs to enable different orders per receiver.
 	 */
 	private static void createReceiverOrders( Scenario sc ) {
-		Carriers carriers = ReceiverUtils.getCarriers( sc );
+		Carriers carriers = FreightUtils.getCarriers(sc);
 		Receivers receivers = ReceiverUtils.getReceivers( sc );
 		Carrier carrierOne = carriers.getCarriers().get(Id.create("Carrier1", Carrier.class));
 
@@ -347,9 +348,9 @@ public class BaseReceiverChessboardScenario{
 		types.getVehicleTypes().put(typeLight.getId(), typeLight);
 		types.getVehicleTypes().put(typeHeavy.getId(), typeHeavy);
 
-		Carriers carriers = new Carriers();
+		Carriers carriers = FreightUtils.getOrCreateCarriers(sc);
 		carriers.addCarrier(carrier);
-		ReceiverUtils.setCarriers(carriers, sc);
+
 	}
 
 

--- a/src/main/java/receiver/usecases/chessboard/BaseRunReceiver.java
+++ b/src/main/java/receiver/usecases/chessboard/BaseRunReceiver.java
@@ -21,29 +21,16 @@
 package receiver.usecases.chessboard;
 
 import org.apache.log4j.Logger;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.contrib.freight.carrier.CarrierVehicleTypeLoader;
-import org.matsim.contrib.freight.carrier.CarrierVehicleTypeReader;
-import org.matsim.contrib.freight.carrier.CarrierVehicleTypes;
-import org.matsim.contrib.freight.carrier.Carriers;
 import org.matsim.contrib.freight.usecases.analysis.CarrierScoreStats;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
-import org.matsim.core.controler.events.IterationEndsEvent;
-import org.matsim.core.utils.io.IOUtils;
-import receiver.Receiver;
 import receiver.ReceiverModule;
-import receiver.ReceiverUtils;
-import receiver.product.Order;
-import receiver.product.ReceiverOrder;
-import receiver.replanning.ReceiverReplanningType;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -167,7 +154,7 @@ class BaseRunReceiver{
 	 */
 	@Deprecated
 	static void prepareFreightOutputDataAndStats( MatsimServices controler) {
-		CarrierScoreStats scoreStats = new CarrierScoreStats( ReceiverUtils.getCarriers( controler.getScenario() ), controler.getScenario().getConfig().controler().getOutputDirectory() + "/carrier_scores", true);
+		CarrierScoreStats scoreStats = new CarrierScoreStats(FreightUtils.getCarriers(controler.getScenario()), controler.getScenario().getConfig().controler().getOutputDirectory() + "/carrier_scores", true);
 		controler.addControlerListener(scoreStats);
 	}
 

--- a/src/main/java/receiver/usecases/chessboard/MarginalReceiverClass.java
+++ b/src/main/java/receiver/usecases/chessboard/MarginalReceiverClass.java
@@ -26,6 +26,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.carrier.CarrierPlanXmlWriterV2;
 import org.matsim.contrib.freight.usecases.analysis.CarrierScoreStats;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.MatsimServices;
@@ -84,12 +85,12 @@ import java.net.URL;
 //		MarginalScenarioBuilder.generateCarrierPlan( ReceiverUtils.getCarriers( sc ), sc.getNetwork(),  "input/algorithm.xml");
 //		URL algoConfigFileName = IOUtils.newUrl( sc.getConfig().getContext(), "algorithm.xml" );
 		URL algoConfigFileName = IOUtils.extendUrl( sc.getConfig().getContext(), "initialPlanAlgorithm.xml" );
-		ReceiverChessboardUtils.generateCarrierPlan( ReceiverUtils.getCarriers( sc ), sc.getNetwork(),  algoConfigFileName);
+		ReceiverChessboardUtils.generateCarrierPlan(FreightUtils.getCarriers(sc), sc.getNetwork(),  algoConfigFileName);
 		
 		BaseReceiverChessboardScenario.writeFreightScenario(sc );
 		
 		/* Link the carriers to the receivers. */
-		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers( ReceiverUtils.getCarriers( sc ) );
+		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers(FreightUtils.getCarriers(sc));
 		
 		CollaborationUtils.createCoalitionWithCarriersAndAddCollaboratingReceivers( sc );
 
@@ -117,7 +118,7 @@ import java.net.URL;
 		 */
 //		final int statInterval = ReceiverUtils.getReplanInterval( controler.getScenario() );
 		final int statInterval = ExperimentParameters.STAT_INTERVAL;
-		CarrierScoreStats scoreStats = new CarrierScoreStats( ReceiverUtils.getCarriers( controler.getScenario() ), controler.getScenario().getConfig().controler().getOutputDirectory() + "/carrier_scores", true);
+		CarrierScoreStats scoreStats = new CarrierScoreStats(FreightUtils.getCarriers(controler.getScenario()), controler.getScenario().getConfig().controler().getOutputDirectory() + "/carrier_scores", true);
 
 		controler.addControlerListener(scoreStats);
 
@@ -127,7 +128,7 @@ import java.net.URL;
 				String dir = event.getServices().getControlerIO().getIterationPath(event.getIteration());
 				if((event.getIteration() + 1) % (statInterval) != 0) return;
 				//write plans
-				new CarrierPlanXmlWriterV2( ReceiverUtils.getCarriers( controler.getScenario() ) ).write(dir + "/" + event.getIteration() + ".carrierPlans.xml.gz");
+				new CarrierPlanXmlWriterV2(FreightUtils.getCarriers(controler.getScenario())).write(dir + "/" + event.getIteration() + ".carrierPlans.xml.gz");
 				LOG.info("Writing carrier plans to: " + dir + "/" + event.getIteration() + ".carrierPlans.xml.gz");
 			}
 		});

--- a/src/main/java/receiver/usecases/chessboard/MarginalScenarioBuilder.java
+++ b/src/main/java/receiver/usecases/chessboard/MarginalScenarioBuilder.java
@@ -34,7 +34,6 @@ import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.vehicles.VehicleType;
@@ -90,7 +89,7 @@ public class MarginalScenarioBuilder {
 		}
 		
 		/* Link the carriers to the receivers. */
-		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers( ReceiverUtils.getCarriers( sc ) );
+		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers(FreightUtils.getCarriers(sc));
 		CollaborationUtils.createCoalitionWithCarriersAndAddCollaboratingReceivers( sc );
 		return sc;
 	}
@@ -143,7 +142,7 @@ public class MarginalScenarioBuilder {
 	 * for experiments, but this must be adapted in the future to accept other parameters as inputs to enable different orders per receiver. 
 	 */
 	static void createReceiverOrders( Scenario sc) {
-		Carriers carriers = ReceiverUtils.getCarriers( sc );
+		Carriers carriers = FreightUtils.getCarriers(sc);
 		Receivers receivers = ReceiverUtils.getReceivers( sc );
 		Carrier carrierOne = carriers.getCarriers().get(Id.create("Carrier1", Carrier.class));
 
@@ -268,10 +267,8 @@ public class MarginalScenarioBuilder {
 		types.getVehicleTypes().put(typeLight.getId(), typeLight);
 		types.getVehicleTypes().put(typeHeavy.getId(), typeHeavy);
 
-		Carriers carriers = new Carriers();
+		Carriers carriers = FreightUtils.getOrCreateCarriers(sc);
 		carriers.addCarrier(carrier);
-		
-		ReceiverUtils.setCarriers(carriers, sc);
 	}
 
 

--- a/src/main/java/receiver/usecases/chessboard/ProportionalReceiverChessboardScenario.java
+++ b/src/main/java/receiver/usecases/chessboard/ProportionalReceiverChessboardScenario.java
@@ -36,6 +36,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.ConfigWriter;
@@ -92,7 +93,7 @@ class ProportionalReceiverChessboardScenario {
 		}
 		
 		/* Link the carriers to the receivers. */
-		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers( ReceiverUtils.getCarriers( sc ) );
+		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers(FreightUtils.getCarriers(sc));
 		CollaborationUtils.createCoalitionWithCarriersAndAddCollaboratingReceivers( sc );
 		return sc;
 	}
@@ -161,9 +162,8 @@ class ProportionalReceiverChessboardScenario {
 		types.getVehicleTypes().put(typeLight.getId(), typeLight);
 		types.getVehicleTypes().put(typeHeavy.getId(), typeHeavy);
 
-		Carriers carriers = new Carriers();
+		Carriers carriers = FreightUtils.getOrCreateCarriers(sc);
 		carriers.addCarrier(carrier);
-		ReceiverUtils.setCarriers(carriers, sc);
 	}
 
 
@@ -256,13 +256,13 @@ class ProportionalReceiverChessboardScenario {
 		new File(outputFolder).mkdirs();
 		
 		new ConfigWriter(sc.getConfig()).write(outputFolder + "config.xml");
-		new CarrierPlanXmlWriterV2( ReceiverUtils.getCarriers( sc ) ).write(outputFolder + "carriers.xml");
+		new CarrierPlanXmlWriterV2(FreightUtils.getCarriers(sc)).write(outputFolder + "carriers.xml");
 		new ReceiversWriter( ReceiverUtils.getReceivers( sc ) ).write(outputFolder + "receivers.xml");
 
 		/* Write the vehicle types. FIXME This will have to change so that vehicle
 		 * types lie at the Carriers level, and not per Carrier. In this scenario 
 		 * there luckily is only a single Carrier. */
-		new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes( ReceiverUtils.getCarriers( sc ) )).write(outputFolder + "carrierVehicleTypes.xml");
+		new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes(FreightUtils.getCarriers(sc))).write(outputFolder + "carrierVehicleTypes.xml");
 	}
 
 
@@ -272,7 +272,7 @@ class ProportionalReceiverChessboardScenario {
 	 * @param sc
 	 */
 	public static void createReceiverOrders( Scenario sc) {
-		Carriers carriers = ReceiverUtils.getCarriers( sc );
+		Carriers carriers = FreightUtils.getCarriers(sc);
 		Receivers receivers = ReceiverUtils.getReceivers( sc );
 		Carrier carrierOne = carriers.getCarriers().get(Id.create("Carrier1", Carrier.class));
 

--- a/src/main/java/receiver/usecases/chessboard/ProportionalRunReceiver.java
+++ b/src/main/java/receiver/usecases/chessboard/ProportionalRunReceiver.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.usecases.analysis.CarrierScoreStats;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.MatsimServices;
@@ -33,7 +34,6 @@ import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.utils.io.IOUtils;
 
 import receiver.ReceiverModule;
-import receiver.ReceiverUtils;
 
 /**
  * Specific example for my (wlbean) thesis chapters 5 and 6.
@@ -107,7 +107,7 @@ class ProportionalRunReceiver{
 	 */
 	@Deprecated
 	static void prepareFreightOutputDataAndStats( MatsimServices controler) {
-		CarrierScoreStats scoreStats = new CarrierScoreStats( ReceiverUtils.getCarriers( controler.getScenario() ), controler.getScenario().getConfig().controler().getOutputDirectory() + "/carrier_scores", true);
+		CarrierScoreStats scoreStats = new CarrierScoreStats(FreightUtils.getCarriers(controler.getScenario()), controler.getScenario().getConfig().controler().getOutputDirectory() + "/carrier_scores", true);
 		controler.addControlerListener(scoreStats);
 	}
 }

--- a/src/main/java/receiver/usecases/chessboard/ProportionalScenarioBuilder.java
+++ b/src/main/java/receiver/usecases/chessboard/ProportionalScenarioBuilder.java
@@ -29,6 +29,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.freight.carrier.*;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.ConfigWriter;
@@ -81,14 +82,14 @@ class ProportionalScenarioBuilder {
 		/* Let jsprit do its magic and route the given receiver orders. */
 //		generateCarrierPlan(ReceiverUtils.getCarriers( sc ), sc.getNetwork(), "./scenarios/chessboard/vrpalgo/initialPlanAlgorithm.xml");
 		URL algoConfigFileName = IOUtils.extendUrl(sc.getConfig().getContext(), "initialPlanAlgorithm.xml" );
-		ReceiverChessboardUtils.generateCarrierPlan(ReceiverUtils.getCarriers( sc ), sc.getNetwork(), algoConfigFileName);
+		ReceiverChessboardUtils.generateCarrierPlan(FreightUtils.getCarriers(sc), sc.getNetwork(), algoConfigFileName);
 		
 		if(write) {
 			writeFreightScenario(sc);
 		}
 		
 		/* Link the carriers to the receivers. */
-		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers( ReceiverUtils.getCarriers( sc ) );
+		ReceiverUtils.getReceivers( sc ).linkReceiverOrdersToCarriers(FreightUtils.getCarriers(sc));
 		
 		CollaborationUtils.createCoalitionWithCarriersAndAddCollaboratingReceivers( sc );
 
@@ -158,13 +159,13 @@ class ProportionalScenarioBuilder {
 		new File(outputFolder).mkdirs();
 		
 		new ConfigWriter(sc.getConfig()).write(outputFolder + "config.xml");
-		new CarrierPlanXmlWriterV2( ReceiverUtils.getCarriers( sc ) ).write(outputFolder + "carriers.xml");
+		new CarrierPlanXmlWriterV2(FreightUtils.getCarriers(sc)).write(outputFolder + "carriers.xml");
 //		new ReceiversWriter( ReceiverUtils.getReceivers( sc ) ).write(outputFolder + "receivers.xml");
 
 		/* Write the vehicle types. FIXME This will have to change so that vehicle
 		 * types lie at the Carriers level, and not per Carrier. In this scenario 
 		 * there luckily is only a single Carrier. */
-		new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes( ReceiverUtils.getCarriers( sc ) )).write(outputFolder + "carrierVehicleTypes.xml");
+		new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes(FreightUtils.getCarriers(sc))).write(outputFolder + "carrierVehicleTypes.xml");
 	}
 
 
@@ -174,7 +175,7 @@ class ProportionalScenarioBuilder {
 	 * @param sc
 	 */
 	public static void createReceiverOrders( Scenario sc) {
-		Carriers carriers = ReceiverUtils.getCarriers( sc );
+		Carriers carriers = FreightUtils.getCarriers(sc);
 		Receivers receivers = ReceiverUtils.getReceivers( sc );
 		Carrier carrierOne = carriers.getCarriers().get(Id.create("Carrier1", Carrier.class));
 

--- a/src/main/java/receiver/usecases/chessboard/ReceiverChessboardUtils.java
+++ b/src/main/java/receiver/usecases/chessboard/ReceiverChessboardUtils.java
@@ -34,6 +34,7 @@ import com.graphhopper.jsprit.io.algorithm.VehicleRoutingAlgorithms;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.freight.Freight;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.CarrierPlan;
@@ -45,6 +46,7 @@ import org.matsim.contrib.freight.jsprit.NetworkBasedTransportCosts;
 import org.matsim.contrib.freight.jsprit.NetworkRouter;
 import org.matsim.contrib.freight.controler.CarrierPlanStrategyManagerFactory;
 import org.matsim.contrib.freight.controler.CarrierScoringFunctionFactory;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
 
@@ -61,7 +63,7 @@ public class ReceiverChessboardUtils {
 	final public static int STATISTICS_INTERVAL = 50;
 	
 	public static void setupCarriers(Controler controler) {
-		Carriers carriers = ReceiverUtils.getCarriers( controler.getScenario() );;
+		Carriers carriers = FreightUtils.getOrCreateCarriers(controler.getScenario());;
 
 		BaseRunReceiver.setupCarrierReplanning(controler );
 
@@ -73,14 +75,9 @@ public class ReceiverChessboardUtils {
 			  controler.getScenario().getNetwork(), controler);
 
 		FreightConfigGroup freightConfig = ConfigUtils.addOrGetModule( controler.getScenario().getConfig(), FreightConfigGroup.class );
-		if ( true ){
-			freightConfig.setTimeWindowHandling( FreightConfigGroup.TimeWindowHandling.enforceBeginnings );
-		} else{
-			freightConfig.setTimeWindowHandling( FreightConfigGroup.TimeWindowHandling.ignore );
-		}
+		freightConfig.setTimeWindowHandling( FreightConfigGroup.TimeWindowHandling.enforceBeginnings );
 
-		CarrierModule carrierControler = new CarrierModule(carriers, cStratManFac, cScorFuncFac);
-//		carrierControler.setPhysicallyEnforceTimeWindowBeginnings(true);
+		CarrierModule carrierControler = new CarrierModule(cStratManFac, cScorFuncFac);
 		controler.addOverridingModule(carrierControler);
 	}
 

--- a/src/main/java/receiver/usecases/chessboard/ReceiverChessboardUtils.java
+++ b/src/main/java/receiver/usecases/chessboard/ReceiverChessboardUtils.java
@@ -63,7 +63,7 @@ public class ReceiverChessboardUtils {
 	final public static int STATISTICS_INTERVAL = 50;
 	
 	public static void setupCarriers(Controler controler) {
-		Carriers carriers = FreightUtils.getOrCreateCarriers(controler.getScenario());;
+		Carriers carriers = FreightUtils.getCarriers(controler.getScenario());;
 
 		BaseRunReceiver.setupCarrierReplanning(controler );
 

--- a/src/test/java/receiver/collaboration/ProportionalCostSharingTest.java
+++ b/src/test/java/receiver/collaboration/ProportionalCostSharingTest.java
@@ -19,15 +19,12 @@
 package receiver.collaboration;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.utils.FreightUtils;
-import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.testcases.MatsimTestUtils;
 
 import receiver.Receiver;
@@ -36,7 +33,6 @@ import receiver.product.Order;
 import receiver.usecases.chessboard.BaseReceiverChessboardScenario;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Objects;
 
 public class ProportionalCostSharingTest {
@@ -49,7 +45,7 @@ public class ProportionalCostSharingTest {
     public void test() {
         setup();
 
-        Carrier carrier = ReceiverUtils.getCarriers(sc).getCarriers().get(Id.create("Carrier1", Carrier.class));
+		Carrier carrier = FreightUtils.getCarriers(sc).getCarriers().get(Id.create("Carrier1", Carrier.class));
         double carrierCost = carrier.getSelectedPlan().getScore();
 
         double total = 0.0;
@@ -79,7 +75,7 @@ public class ProportionalCostSharingTest {
         this.sc = BaseReceiverChessboardScenario.createChessboardScenario(1L, 1, 5, false);
 
         /* Manipulate the carrier as it has no plan or score without a simulation run. */
-        Carrier carrier = ReceiverUtils.getCarriers(this.sc).getCarriers().get(Id.create("Carrier1", Carrier.class));
+		Carrier carrier = FreightUtils.getCarriers(this.sc).getCarriers().get(Id.create("Carrier1", Carrier.class));
         CarrierPlan plan = new CarrierPlan(carrier, new ArrayList<>());
         plan.setScore(-10000.);
         carrier.setSelectedPlan(plan);

--- a/src/test/java/receiver/usecases/chessboard/BaseRunReceiverIT.java
+++ b/src/test/java/receiver/usecases/chessboard/BaseRunReceiverIT.java
@@ -8,6 +8,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.CarrierPlan;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.events.IterationEndsEvent;
@@ -56,7 +57,7 @@ public class BaseRunReceiverIT {
                                 }
                             }
                         }
-                        for (Carrier carrier : ReceiverUtils.getCarriers(scenario).getCarriers().values()) {
+                        for (Carrier carrier : FreightUtils.getCarriers(scenario).getCarriers().values()) {
                             Assert.assertEquals(-8692.92, carrier.getSelectedPlan().getScore(), 1.);
                         }
                     }
@@ -133,7 +134,7 @@ public class BaseRunReceiverIT {
                 }
             }
             log.warn("");
-            for (Carrier carrier : ReceiverUtils.getCarriers(scenario).getCarriers().values()) {
+            for (Carrier carrier : FreightUtils.getCarriers(scenario).getCarriers().values()) {
                 for (CarrierPlan plan : carrier.getPlans()) {
                     StringBuilder strb = new StringBuilder();
                     strb.append("carrierId=").append(plan.getCarrier().getId());


### PR DESCRIPTION
This PR 

1.  fixes compile errors after matsim-org/matsim-libs#1330 (taking out carriers from the carrierModule constructor). close #30 
2.  removes the internal definition of an `Carrier_Scenario_Element `within the `RecieverUtils` class. I replaced it by using the  infrastructure from the MATSim freight contrib: `FreightUtils.getOrCreateCarriers(scenario)` ... 
This was done because after 1.) I got some errors because the scenarioElement was spelled differently in Freight and here (**c**arriers vs **C**arriers). This can be avoided by using the central one and avoid the local naming of the scenarioElement. To reach this I did some inlining, replacements and commented out the previous code and no longer needed code within ReceiverUtils.
